### PR TITLE
fix: Sync with `upstream/master` (Commit b9b3605)

### DIFF
--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -55,7 +55,7 @@ func initConfig() {
 
 	// version checker
 	if os.Getenv("GEN3_CLIENT_VERSION_CHECK") != "false" &&
-	gitversion != "" && gitversion != "N/A" {
+		gitversion != "" && gitversion != "N/A" {
 		githubTag := &latest.GithubTag{
 			Owner:      "uc-cdis",
 			Repository: "cdis-data-client",
@@ -78,13 +78,16 @@ func initConfig() {
 				return true
 			},
 		}
-		res, err := latest.Check(githubTag, gitversion)
-		if err != nil {
-			log.Println("Error occurred when checking for latest version: " + err.Error())
-		} else if res.Outdated {
-			log.Println("A new version of gen3-client is available! The latest version is " + res.Current + ". You are using version " + gitversion)
-			log.Println("Please download the latest gen3-client release from https://github.com/uc-cdis/cdis-data-client/releases/latest")
-		}
+
+		// Commenting out version check for now to reduce confusion
+		//
+		// 	res, err := latest.Check(githubTag, gitversion)
+		// 	if err != nil {
+		// 		log.Println("Error occurred when checking for latest version: " + err.Error())
+		// 	} else if res.Outdated {
+		// 		log.Println("A new version of gen3-client is available! The latest version is " + res.Current + ". You are using version " + gitversion)
+		// 		log.Println("Please download the latest gen3-client release from https://github.com/uc-cdis/cdis-data-client/releases/latest")
+		// 	}
 	}
 	logs.SetToMessageLog()
 }

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -55,7 +55,7 @@ func initConfig() {
 
 	// version checker
 	// Temp. disabling version check message to reduce confusion
-	if os.Getenv("GEN3_CLIENT_VERSION_CHECK") != "true" &&
+	if false && os.Getenv("GEN3_CLIENT_VERSION_CHECK") != "false" &&
 		gitversion != "" && gitversion != "N/A" {
 		githubTag := &latest.GithubTag{
 			Owner:      "uc-cdis",

--- a/gen3-client/g3cmd/root.go
+++ b/gen3-client/g3cmd/root.go
@@ -54,7 +54,8 @@ func initConfig() {
 	}
 
 	// version checker
-	if os.Getenv("GEN3_CLIENT_VERSION_CHECK") != "false" &&
+	// Temp. disabling version check message to reduce confusion
+	if os.Getenv("GEN3_CLIENT_VERSION_CHECK") != "true" &&
 		gitversion != "" && gitversion != "N/A" {
 		githubTag := &latest.GithubTag{
 			Owner:      "uc-cdis",
@@ -79,15 +80,13 @@ func initConfig() {
 			},
 		}
 
-		// Commenting out version check for now to reduce confusion
-		//
-		// 	res, err := latest.Check(githubTag, gitversion)
-		// 	if err != nil {
-		// 		log.Println("Error occurred when checking for latest version: " + err.Error())
-		// 	} else if res.Outdated {
-		// 		log.Println("A new version of gen3-client is available! The latest version is " + res.Current + ". You are using version " + gitversion)
-		// 		log.Println("Please download the latest gen3-client release from https://github.com/uc-cdis/cdis-data-client/releases/latest")
-		// 	}
+		res, err := latest.Check(githubTag, gitversion)
+		if err != nil {
+			log.Println("Error occurred when checking for latest version: " + err.Error())
+		} else if res.Outdated {
+			log.Println("A new version of gen3-client is available! The latest version is " + res.Current + ". You are using version " + gitversion)
+			log.Println("Please download the latest gen3-client release from https://github.com/uc-cdis/cdis-data-client/releases/latest")
+		}
 	}
 	logs.SetToMessageLog()
 }

--- a/gen3-client/g3cmd/upload-multiple.go
+++ b/gen3-client/g3cmd/upload-multiple.go
@@ -79,44 +79,13 @@ func init() {
 				log.Fatalf("Error when parsing file paths: " + err.Error())
 			}
 
-			for i, furObject := range furObjects {
-				if batch {
-					if len(batchFURObjects) < workers {
-						batchFURObjects = append(batchFURObjects, furObject)
-					} else {
-						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName)
-						batchFURObjects = make([]commonUtils.FileUploadRequestObject, 0)
-						batchFURObjects = append(batchFURObjects, furObject)
-					}
-					if i == len(furObjects)-1 { // upload remainders
-						batchUpload(gen3Interface, batchFURObjects, workers, respCh, errCh, bucketName)
-					}
-				} else {
-					file, err := os.Open(furObject.FilePath)
-					if err != nil {
-						log.Println("File open error: " + err.Error())
-						logs.AddToFailedLog(furObject.FilePath, furObject.Filename, commonUtils.FileMetadata{}, furObject.GUID, 0, false, true)
-						logs.IncrementScore(logs.ScoreBoardLen - 1)
-						continue
-					}
-					defer file.Close()
-
-					furObject, err := GenerateUploadRequest(gen3Interface, furObject, file)
-					if err != nil {
-						file.Close()
-						logs.AddToFailedLog(furObject.FilePath, furObject.Filename, commonUtils.FileMetadata{}, furObject.GUID, 0, false, true)
-						logs.IncrementScore(logs.ScoreBoardLen - 1)
-						log.Printf("Error occurred during request generation: %s", err.Error())
-						continue
-					}
-					err = uploadFile(furObject, 0)
-					if err != nil {
-						log.Println(err.Error())
-						logs.IncrementScore(logs.ScoreBoardLen - 1)
-					} else {
-						logs.IncrementScore(0)
-					}
-					file.Close()
+			filePaths := make([]string, 0)
+			for _, object := range objects {
+				// Here we are assuming the local filename will be the same as GUID
+				filePath, err := getFullFilePath(uploadPath, object.ObjectID)
+				if err != nil {
+					log.Println(err.Error())
+					continue
 				}
 				filePaths = append(filePaths, filePath)
 			}
@@ -167,7 +136,9 @@ func init() {
 	uploadMultipleCmd.MarkFlagRequired("upload-path") //nolint:errcheck
 	uploadMultipleCmd.Flags().BoolVar(&batch, "batch", true, "Upload in parallel")
 	uploadMultipleCmd.Flags().IntVar(&numParallel, "numparallel", 3, "Number of uploads to run in parallel")
-	uploadMultipleCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded")
+	uploadMultipleCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded. If not provided, defaults to Gen3's configured DATA_UPLOAD_BUCKET.")
+	uploadMultipleCmd.Flags().BoolVar(&forceMultipart, "force-multipart", false, "Force to use multipart upload when possible (file size >= 5MB)")
+	uploadMultipleCmd.Flags().BoolVar(&includeSubDirName, "include-subdirname", false, "Include subdirectory names in file name")
 	RootCmd.AddCommand(uploadMultipleCmd)
 }
 

--- a/gen3-client/g3cmd/upload-single.go
+++ b/gen3-client/g3cmd/upload-single.go
@@ -95,6 +95,6 @@ func init() {
 	uploadSingleCmd.MarkFlagRequired("guid") //nolint:errcheck
 	uploadSingleCmd.Flags().StringVar(&filePath, "file", "", "Specify file to upload to with --file=~/path/to/file")
 	uploadSingleCmd.MarkFlagRequired("file") //nolint:errcheck
-	uploadSingleCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded")
+	uploadSingleCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded. If not provided, defaults to Gen3's configured DATA_UPLOAD_BUCKET.")
 	RootCmd.AddCommand(uploadSingleCmd)
 }

--- a/gen3-client/g3cmd/upload.go
+++ b/gen3-client/g3cmd/upload.go
@@ -154,26 +154,7 @@ func init() {
 			if len(multipartFilePaths) > 0 {
 				// NOTE(@mpingram) - For the moment Shepherd doesn't support multipart uploads.
 				// Throw an error if Shepherd is enabled and user attempts to multipart upload.
-				profileConfig := conf.ParseConfig(profile)
-				if profileConfig.UseShepherd == "true" ||
-					profileConfig.UseShepherd == "" && commonUtils.DefaultUseShepherd == true {
-					log.Fatalf("Error: Shepherd currently does not support multipart uploads. For the moment, please disable Shepherd with\n	$ gen3-client configure --profile=%v --use-shepherd=false\nand try again.\n", profile)
-				}
-				log.Println("Multipart uploading....")
-				for _, filePath := range multipartFilePaths {
-					fileInfo, err := ProcessFilename(uploadPath, filePath, includeSubDirName, false)
-					if err != nil {
-						logs.AddToFailedLog(filePath, filepath.Base(filePath), commonUtils.FileMetadata{}, "", 0, false, true)
-						log.Println("Process filename error for file: " + err.Error())
-						continue
-					}
-					err = multipartUpload(gen3Interface, fileInfo, 0, bucketName)
-					if err != nil {
-						log.Println(err.Error())
-					} else {
-						logs.IncrementScore(0)
-					}
-				}
+				processMultipartUpload(gen3Interface, multipartFilePaths, bucketName, includeSubDirName, uploadPath)
 			}
 
 			if !logs.IsFailedLogMapEmpty() {
@@ -193,6 +174,6 @@ func init() {
 	uploadCmd.Flags().BoolVar(&includeSubDirName, "include-subdirname", false, "Include subdirectory names in file name")
 	uploadCmd.Flags().BoolVar(&forceMultipart, "force-multipart", false, "Force to use multipart upload if possible")
 	uploadCmd.Flags().BoolVar(&hasMetadata, "metadata", false, "Search for and upload file metadata alongside the file")
-	uploadCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded")
+	uploadCmd.Flags().StringVar(&bucketName, "bucket", "", "The bucket to which files will be uploaded. If not provided, defaults to Gen3's configured DATA_UPLOAD_BUCKET.")
 	RootCmd.AddCommand(uploadCmd)
 }

--- a/gen3-client/g3cmd/utils.go
+++ b/gen3-client/g3cmd/utils.go
@@ -537,37 +537,6 @@ func getFullFilePath(filePath string, filename string) (string, error) {
 	}
 }
 
-func validateObject(objects []ManifestObject, uploadPath string) []commonUtils.FileUploadRequestObject {
-	furObjects := make([]commonUtils.FileUploadRequestObject, 0)
-	for _, object := range objects {
-		guid := object.ObjectID
-		var fileName = ""
-
-		if object.Filename != "" {
-		    // conform to fence naming convention
-		    fileName = object.Filename
-		} else {
-			// Otherwise, here we are assuming the local filename will be the same as GUID
-			fileName = object.ObjectID
-		}
-
-		filePath, err := getFullFilePath(uploadPath, fileName)
-		if err != nil {
-			log.Println(err.Error())
-			continue
-		}
-
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			log.Printf("The file you specified \"%s\" does not exist locally.\n", filePath)
-			continue
-		}
-
-		furObject := commonUtils.FileUploadRequestObject{FilePath: filePath, Filename: fileName, GUID: guid}
-		furObjects = append(furObjects, furObject)
-	}
-	return furObjects
-}
-
 func uploadFile(furObject commonUtils.FileUploadRequestObject, retryCount int) error {
 	log.Println("Uploading data ...")
 	furObject.Bar.Start()


### PR DESCRIPTION
# Overview 🌱

This PR reverts changes to OHSU's forked version of gen3-client in order to fix compilation issues related to the unbound furObjects variable.

This PR will make our [master](https://github.com/ACED-IDP/cdis-data-client/tree/master) branch identical to that of [upstream's](https://github.com/uc-cdis/cdis-data-client/tree/master) (including the updates from https://github.com/uc-cdis/cdis-data-client/pull/123 required to run multipart uploads to non-AWS S3 buckets).

> [!IMPORTANT]
> This PR also resolves [CALYPR Issue #6 ](https://github.com/orgs/calypr/projects/4/views/1?filterQuery=gen3-client&pane=issue&itemId=135479852&issue=calypr%7Cdata-client%7C6) related to the misleading version message being included in the command output

## Previous Behavior ❌

Compile errors:

```sh
➜ go build -o cdis-data-client
# github.com/uc-cdis/gen3-client/gen3-client/g3cmd
gen3-client/g3cmd/upload-multiple.go:82:30: undefined: furObjects
gen3-client/g3cmd/upload-multiple.go:84:13: undefined: batchFURObjects
gen3-client/g3cmd/upload-multiple.go:84:32: undefined: workers
gen3-client/g3cmd/upload-multiple.go:85:32: undefined: batchFURObjects
gen3-client/g3cmd/upload-multiple.go:87:34: undefined: batchFURObjects
gen3-client/g3cmd/upload-multiple.go:87:51: undefined: workers
gen3-client/g3cmd/upload-multiple.go:87:60: undefined: respCh
gen3-client/g3cmd/upload-multiple.go:87:68: undefined: errCh
gen3-client/g3cmd/upload-multiple.go:88:7: undefined: batchFURObjects
gen3-client/g3cmd/upload-multiple.go:89:32: undefined: batchFURObjects
gen3-client/g3cmd/upload-multiple.go:89:32: too many errors
```

## Sync 🌀

> [!TIP]
> Upstream Commit [b9b3605](https://github.com/uc-cdis/cdis-data-client/commit/b9b360561b6fdd7127c6c673d2b948f3495a2122#diff-5da4bdf802d2fb9b23bc8713fdf38123ffd9e1b276905768bb0f934f54444486)

```sh
➜ git clone git@github.com:calypr/data-client.git
Cloning into 'data-client'...

➜ cd data-client

git show --oneline
a66704f (HEAD -> master, origin/master, origin/HEAD) Merge branch 'uc-cdis:master' into master

➜ git remote add upstream https://github.com/uc-cdis/cdis-data-client

➜ git fetch --all
Fetching origin
Fetching upstream

➜ git cherry-pick b9b3605 -X theirs
Auto-merging gen3-client/g3cmd/upload-multiple.go
Auto-merging gen3-client/g3cmd/upload-single.go
Auto-merging gen3-client/g3cmd/upload.go
Auto-merging gen3-client/g3cmd/utils.go
[fix/compile 3cab9cb] (PPS-411): Add bucket selection support for multi part upload (#123)
 Author: Binam Bajracharya <44302895+BinamB@users.noreply.github.com>
 Date: Mon Jan 22 12:59:20 2024 -0500
 4 files changed, 13 insertions(+), 92 deletions(-)

➜ git push
To github.com:calypr/data-client.git
 * [new branch]      fix/compile -> fix/compile
branch '[fix/compile](https://github.com/calypr/data-client/tree/fix/compile)' set up to track 'origin/fix/compile'.
```

## New Behavior ✅

Successful compilation!

```sh
➜ go build -o cdis-data-client

➜ ls cdis-data-client
cdis-data-client

➜ ./cdis-data-client
Gen3 Client for downloading, uploading and submitting data to data commons.
gen3-client version: N/A, commit: N/A
```

## Test Steps ✍️

> Adapted from the [Download and Upload Files Using the Gen3-client](https://gen3.org/resources/user/gen3-client/#3-upload-data-files) and [Upload Data Files using the Gen3 Client](https://docs.gen3.org/gen3-resources/operator-guide/submit-unstructured-data/#3-upload-data-files-using-the-gen3-client)

### 1. Build `gen3-client`

```sh
➜ which gen3-client
~/.gen3/gen3-client

➜ mv ~/.gen3/gen3-client ~/.gen3/gen3-client.bak

➜ go build -o ~/.gen3/gen3-client

➜ gen3-client --version
gen3-client version N/A
```

### 2. Upload Single File via `gen3-client`

```sh
➜ echo "This is a test file for gen3-client" > gen3-client-test.txt

➜ gen3-client upload --profile=cbds --upload-path=gen3-client-test.txt
```

- [x] Verify that the gen3-client-test.txt file has been uploaded to the expected bucket

### 3. Upload Single File via calypr_admin

```sh
➜ calypr_admin clone cbds-dev

➜ cd cbds-dev

➜ echo "This is a test file for calypr_admin" > calypr_admin-test.txt

➜ calypr_admin add calypr_admin-test.txt

➜ calypr_admin meta init

➜ calypr_admin commit -m "adding test file"

➜ calypr_admin push

# Then verify that the `calypr_admin-test.txt` file has been uploaded to the expected bucket 
```

## Next Steps 🌀

- [x] Test upload with to non-AWS S3 buckets (previously encountered the issue where a test file appeared to be pushed but did not actually get uploaded to the bucket...
  - This should have been resolved with https://github.com/uc-cdis/cdis-data-client/pull/123 but not yet clear what is causing this bug 🐛
- [x] Verify that the calypr_admin-test.txt file has been uploaded to the expected bucket